### PR TITLE
Feature/airflow config test

### DIFF
--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -1,7 +1,18 @@
 import pytest
+from airflow.configuration import conf
+import logging
 
 
-@pytest.mark.compatibility
-def test_sample():
-    print("rb template compatibility test was called.")
-    return True
+@pytest.mark.parametrize(
+    ("curr_section", "curr_key", "expected_value"),
+    [
+        ("core", "enable_xcom_pickling", "False"),
+    ],
+)
+def test_check_configuration_value(curr_section, curr_key, expected_value):
+    """
+    Checks that airflow.cfg's configurations are set properly for this plugin.
+    """
+    config_val = conf.get(section=curr_section, key=curr_key)
+    logging.info(f"{ curr_section }.{ curr_key } is set to { config_val }")
+    assert config_val == expected_value


### PR DESCRIPTION
- adds tests to ensure airflow.cfg is configured properly (ie. `enable_xcom_pickling = False`)